### PR TITLE
Add Spanish, French, and Swedish localizations for formatting options

### DIFF
--- a/stringResources/en-US/resources.resjson
+++ b/stringResources/en-US/resources.resjson
@@ -1,7 +1,7 @@
 {
-    "F_Formatting" : "Format",
-    "F_FontFamily" : "Font Family",
-    "F_FontSize" : "Text Size",
-    "F_BackgroundColor" : "Background Color",
-    "F_F_FontColor" : "Text Color"
+    "F_Formatting": "Format",
+    "F_FontFamily": "Font Family",
+    "F_FontSize": "Text Size",
+    "F_BackgroundColor": "Background Color",
+    "F_FontColor": "Text Color"
 }

--- a/stringResources/es-ES/resources.resjson
+++ b/stringResources/es-ES/resources.resjson
@@ -1,0 +1,7 @@
+{
+    "F_Formatting": "Formato",
+    "F_FontFamily": "Familia de fuente",
+    "F_FontSize": "Tamaño de texto",
+    "F_BackgroundColor": "Color de fondo",
+    "F_FontColor": "Color de texto"
+}

--- a/stringResources/fr-FR/resources.resjson
+++ b/stringResources/fr-FR/resources.resjson
@@ -1,0 +1,7 @@
+{
+    "F_Formatting": "Format",
+    "F_FontFamily": "Police",
+    "F_FontSize": "Taille du texte",
+    "F_BackgroundColor": "Couleur de fond",
+    "F_FontColor": "Couleur du texte"
+}

--- a/stringResources/sv-SE/resources.resjson
+++ b/stringResources/sv-SE/resources.resjson
@@ -1,0 +1,7 @@
+{
+    "F_Formatting": "Formatering",
+    "F_FontFamily": "Typsnitt",
+    "F_FontSize": "Textstorlek",
+    "F_BackgroundColor": "Bakgrundsfärg",
+    "F_FontColor": "Textfärg"
+}


### PR DESCRIPTION
This pull request includes updates to the localization files for multiple languages, correcting an issue in the English resource file and adding new entries for Spanish, French, and Swedish.

Localization updates:

* [`stringResources/en-US/resources.resjson`](diffhunk://#diff-602835ceba511e4ac9dcbdb644aaf1246643a7781041e4b0139de19f43b4019bL6-R6): Corrected the key for "Text Color" from `F_F_FontColor` to `F_FontColor`.
* [`stringResources/es-ES/resources.resjson`](diffhunk://#diff-2c610e88d461761c7639d761079ed21e3d7179bf5820204252711aae4dc9cb67R1-R7): Added new entries for formatting-related strings, including font family, text size, background color, and text color.
* [`stringResources/fr-FR/resources.resjson`](diffhunk://#diff-6ead5cbb9ba3c331b1b9c5de3f9267085785aff7ab54d489b12af383f4eda947R1-R7): Added new entries for formatting-related strings, including font family, text size, background color, and text color.
* [`stringResources/sv-SE/resources.resjson`](diffhunk://#diff-2d42490838d518bbf7cd030e46ee7295ad51f460d1bd4c73360ae6f4b770a1fdR1-R7): Added new entries for formatting-related strings, including font family, text size, background color, and text color.